### PR TITLE
Fix broken link for Clojure for Schemers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ mind you).
 * [From REST to CQRS with Clojure, Kafka, & Datomic](https://www.youtube.com/watch?v=qDNPQo9UmJA) [00:44:24] by **Bobby Calderwood**
 * [Game Development Development](https://www.youtube.com/watch?v=ajX09xQ_UEg) [00:35:09] by **Michael Nygard & Ragnar Svensson**
 * [Typed Clojure in Practice](https://www.youtube.com/watch?v=a0gT0syAXsY) [00:41:59] by **Ambrose Bonnaire**
-* [Clojure for Schemers](vimeo.com/22675078) [01:17:27] by **David Nolen**
+* [Clojure for Schemers](https://vimeo.com/22675078) [01:17:27] by **David Nolen**
 
 ####C++
 * [C++17: I See A Monad In Your Future](https://www.youtube.com/watch?v=BFnhhPehpKw) [01:20:59] by **Bartosz Milewski**


### PR DESCRIPTION
The link currently shows up as https://github.com/hellerve/programming-talks/blob/master/vimeo.com/22675078 on GitHub because there is no `https://` in the URL for this talk. This is just a fix for that.
