### PR TITLE
add RailsConf 2017: Keynote by Aaron Patterson

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,6 +778,7 @@ approachable than it actually is, and that is a good thing.
 * [Juggling Patterns and Programs](https://www.youtube.com/watch?v=TqG176T69VM) [00:48:50] by **Steve Miner**
 * [Kolmogorov music](https://www.youtube.com/watch?v=Qg3XOfioapI) [00:42:05] by **Cristopher Ford**
 * [It's not what you read, it's what you ignore](https://www.youtube.com/watch?v=IWPgUn8tL8s) [01:01:52] by **Scott Hanselman**
+* [RailsConf 2017: Keynote](https://www.youtube.com/watch?v=GnCJO8Ax1qg) [00:50:31] by **Aaron Patterson**
 
 ## Contributing
 


### PR DESCRIPTION
I put this under misc because the scope of the talk is broad and features multiple languages.