### PR TITLE
Fix 404 link for Jan Koum Talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,7 +938,7 @@ ever.
 #### Entrepreneurship
 * [Improving Yesterday](https://www.youtube.com/watch?v=2mGl66xHIuw) [00:37:57] by **Eric Fode** (2019)
 * [How and Why to Start A Startup](https://www.startupschool.org/videos/1) [00:44:42] by **Sam Altman & Dustin Moskovitz** (2017)
-* [How to Build a Product (Part IV)](https://www.startupschool.org/videos/8) [00:51:24] by **Jan Koum** (2017)
+* [How to Build a Product (Part IV)](https://www.youtube.com/watch?v=s1Rd4UShDxQ) [00:51:24] by **Jan Koum** (2017)
 * [Barely succeed! It’s easier!](https://www.youtube.com/watch?v=5Vt8zqhHe_c) [00:39:22] by **Maciej Cegłowski** (2013)
 * [Time Management](https://www.youtube.com/watch?v=oTugjssqOT0) [01:16:21] by **Randy Pausch** (2007)
 


### PR DESCRIPTION
The linked Jan Koum Talk on [How to Build a Product](https://www.startupschool.org/videos/8) is missing from `https://startupschool.com`. Added Youtube url for the same talk.